### PR TITLE
Replace dynamic_cast with static_cast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 Icon?
 ehthumbs.db
 Thumbs.db
+
+# vim swap files
+#####################
+*.*sw*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ SET(OUR_EXECUTABLE_OUTPUT_PATH "${PROJECT_BINARY_DIR}/bin")
 ENABLE_TESTING()
 
 # Options
-OPTION(COMPILE_EXAMPLES "Select this if you want to build the examples" OFF)
-OPTION(COMPILE_TESTS "Select this if you want to build the tests" OFF)
+OPTION(COMPILE_EXAMPLES "Select this if you want to build the examples" ON)
+OPTION(COMPILE_TESTS "Select this if you want to build the tests" ON)
 OPTION(PROFILING_ENABLED "Select this if you want to compile with enabled profiling" OFF)
 OPTION(DOUBLE_PRECISION_ENABLED "Select this if you want to compile using double precision floating
                                  values" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ SET(OUR_EXECUTABLE_OUTPUT_PATH "${PROJECT_BINARY_DIR}/bin")
 ENABLE_TESTING()
 
 # Options
-OPTION(COMPILE_EXAMPLES "Select this if you want to build the examples" ON)
-OPTION(COMPILE_TESTS "Select this if you want to build the tests" ON)
+OPTION(COMPILE_EXAMPLES "Select this if you want to build the examples" OFF)
+OPTION(COMPILE_TESTS "Select this if you want to build the tests" OFF)
 OPTION(PROFILING_ENABLED "Select this if you want to compile with enabled profiling" OFF)
 OPTION(DOUBLE_PRECISION_ENABLED "Select this if you want to compile using double precision floating
                                  values" OFF)

--- a/examples/common/Box.h
+++ b/examples/common/Box.h
@@ -120,7 +120,7 @@ inline rp3d::CollisionBody* Box::getCollisionBody() {
 
 // Return a pointer to the rigid body of the box
 inline rp3d::RigidBody* Box::getRigidBody() {
-    return dynamic_cast<rp3d::RigidBody*>(mRigidBody);
+    return static_cast<rp3d::RigidBody*>(mRigidBody);
 }
 
 // Set the color of the box

--- a/examples/common/Capsule.h
+++ b/examples/common/Capsule.h
@@ -88,7 +88,7 @@ inline rp3d::CollisionBody* Capsule::getCollisionBody() {
 
 // Return a pointer to the rigid body of the box
 inline rp3d::RigidBody* Capsule::getRigidBody() {
-    return dynamic_cast<rp3d::RigidBody*>(mRigidBody);
+    return static_cast<rp3d::RigidBody*>(mRigidBody);
 }
 
 #endif

--- a/examples/common/Cone.h
+++ b/examples/common/Cone.h
@@ -87,7 +87,7 @@ inline rp3d::CollisionBody* Cone::getCollisionBody() {
 
 // Return a pointer to the rigid body of the box
 inline rp3d::RigidBody* Cone::getRigidBody() {
-    return dynamic_cast<rp3d::RigidBody*>(mRigidBody);
+    return static_cast<rp3d::RigidBody*>(mRigidBody);
 }
 
 #endif

--- a/examples/common/Sphere.h
+++ b/examples/common/Sphere.h
@@ -84,7 +84,7 @@ inline rp3d::CollisionBody* Sphere::getCollisionBody() {
 
 // Return a pointer to the rigid body of the box
 inline rp3d::RigidBody* Sphere::getRigidBody() {
-    return dynamic_cast<rp3d::RigidBody*>(mRigidBody);
+    return static_cast<rp3d::RigidBody*>(mRigidBody);
 }
 
 #endif

--- a/src/body/RigidBody.cpp
+++ b/src/body/RigidBody.cpp
@@ -342,7 +342,7 @@ void RigidBody::updateBroadPhaseState() const {
 
     PROFILE("RigidBody::updateBroadPhaseState()");
 
-    DynamicsWorld& world = dynamic_cast<DynamicsWorld&>(mWorld);
+    DynamicsWorld& world = static_cast<DynamicsWorld&>(mWorld);
     const Vector3 displacement = world.mTimer.getTimeStep() * mLinearVelocity;
 
     // For all the proxy collision shapes of the body

--- a/src/collision/narrowphase/SphereVsSphereAlgorithm.cpp
+++ b/src/collision/narrowphase/SphereVsSphereAlgorithm.cpp
@@ -48,8 +48,8 @@ bool SphereVsSphereAlgorithm::testCollision(ProxyShape* collisionShape1,
     // Get the sphere collision shapes
     const CollisionShape* shape1 = collisionShape1->getCollisionShape();
     const CollisionShape* shape2 = collisionShape2->getCollisionShape();
-    const SphereShape* sphereShape1 = dynamic_cast<const SphereShape*>(shape1);
-    const SphereShape* sphereShape2 = dynamic_cast<const SphereShape*>(shape2);
+    const SphereShape* sphereShape1 = static_cast<const SphereShape*>(shape1);
+    const SphereShape* sphereShape2 = static_cast<const SphereShape*>(shape2);
 
     // Get the local-space to world-space transforms
     const Transform transform1 = collisionShape1->getBody()->getTransform() *

--- a/src/collision/shapes/BoxShape.h
+++ b/src/collision/shapes/BoxShape.h
@@ -165,7 +165,7 @@ inline Vector3 BoxShape::getLocalSupportPointWithoutMargin(const Vector3& direct
 
 // Test equality between two box shapes
 inline bool BoxShape::isEqualTo(const CollisionShape& otherCollisionShape) const {
-    const BoxShape& otherShape = dynamic_cast<const BoxShape&>(otherCollisionShape);
+    const BoxShape& otherShape = static_cast<const BoxShape&>(otherCollisionShape);
     return (mExtent == otherShape.mExtent);
 }
 

--- a/src/collision/shapes/CapsuleShape.h
+++ b/src/collision/shapes/CapsuleShape.h
@@ -162,7 +162,7 @@ inline void CapsuleShape::getLocalBounds(Vector3& min, Vector3& max) const {
 
 // Test equality between two capsule shapes
 inline bool CapsuleShape::isEqualTo(const CollisionShape& otherCollisionShape) const {
-    const CapsuleShape& otherShape = dynamic_cast<const CapsuleShape&>(otherCollisionShape);
+    const CapsuleShape& otherShape = static_cast<const CapsuleShape&>(otherCollisionShape);
     return (mRadius == otherShape.mRadius && mHalfHeight == otherShape.mHalfHeight);
 }
 

--- a/src/collision/shapes/ConeShape.h
+++ b/src/collision/shapes/ConeShape.h
@@ -178,7 +178,7 @@ inline void ConeShape::computeLocalInertiaTensor(Matrix3x3& tensor, decimal mass
 
 // Test equality between two cone shapes
 inline bool ConeShape::isEqualTo(const CollisionShape& otherCollisionShape) const {
-    const ConeShape& otherShape = dynamic_cast<const ConeShape&>(otherCollisionShape);
+    const ConeShape& otherShape = static_cast<const ConeShape&>(otherCollisionShape);
     return (mRadius == otherShape.mRadius && mHalfHeight == otherShape.mHalfHeight);
 }
 

--- a/src/collision/shapes/ConvexMeshShape.cpp
+++ b/src/collision/shapes/ConvexMeshShape.cpp
@@ -211,7 +211,7 @@ void ConvexMeshShape::recalculateBounds() {
 
 // Test equality between two cone shapes
 bool ConvexMeshShape::isEqualTo(const CollisionShape& otherCollisionShape) const {
-    const ConvexMeshShape& otherShape = dynamic_cast<const ConvexMeshShape&>(otherCollisionShape);
+    const ConvexMeshShape& otherShape = static_cast<const ConvexMeshShape&>(otherCollisionShape);
 
     assert(mNbVertices == mVertices.size());
 

--- a/src/collision/shapes/CylinderShape.h
+++ b/src/collision/shapes/CylinderShape.h
@@ -175,7 +175,7 @@ inline void CylinderShape::computeLocalInertiaTensor(Matrix3x3& tensor, decimal 
 
 // Test equality between two cylinder shapes
 inline bool CylinderShape::isEqualTo(const CollisionShape& otherCollisionShape) const {
-    const CylinderShape& otherShape = dynamic_cast<const CylinderShape&>(otherCollisionShape);
+    const CylinderShape& otherShape = static_cast<const CylinderShape&>(otherCollisionShape);
     return (mRadius == otherShape.mRadius && mHalfHeight == otherShape.mHalfHeight);
 }
 

--- a/src/collision/shapes/SphereShape.h
+++ b/src/collision/shapes/SphereShape.h
@@ -197,7 +197,7 @@ inline void SphereShape::computeAABB(AABB& aabb, const Transform& transform) {
 
 // Test equality between two sphere shapes
 inline bool SphereShape::isEqualTo(const CollisionShape& otherCollisionShape) const {
-    const SphereShape& otherShape = dynamic_cast<const SphereShape&>(otherCollisionShape);
+    const SphereShape& otherShape = static_cast<const SphereShape&>(otherCollisionShape);
     return (mRadius == otherShape.mRadius);
 }
 

--- a/src/engine/ContactSolver.cpp
+++ b/src/engine/ContactSolver.cpp
@@ -83,8 +83,8 @@ void ContactSolver::initializeForIsland(decimal dt, Island* island) {
         assert(externalManifold->getNbContactPoints() > 0);
 
         // Get the two bodies of the contact
-        RigidBody* body1 = dynamic_cast<RigidBody*>(externalManifold->getContactPoint(0)->getBody1());
-        RigidBody* body2 = dynamic_cast<RigidBody*>(externalManifold->getContactPoint(0)->getBody2());
+        RigidBody* body1 = static_cast<RigidBody*>(externalManifold->getContactPoint(0)->getBody1());
+        RigidBody* body2 = static_cast<RigidBody*>(externalManifold->getContactPoint(0)->getBody2());
         assert(body1 != NULL);
         assert(body2 != NULL);
 

--- a/src/engine/DynamicsWorld.cpp
+++ b/src/engine/DynamicsWorld.cpp
@@ -529,7 +529,7 @@ Joint* DynamicsWorld::createJoint(const JointInfo& jointInfo) {
         case BALLSOCKETJOINT:
         {
             void* allocatedMemory = mMemoryAllocator.allocate(sizeof(BallAndSocketJoint));
-            const BallAndSocketJointInfo& info = dynamic_cast<const BallAndSocketJointInfo&>(
+            const BallAndSocketJointInfo& info = static_cast<const BallAndSocketJointInfo&>(
                                                                                         jointInfo);
             newJoint = new (allocatedMemory) BallAndSocketJoint(info);
             break;
@@ -539,7 +539,7 @@ Joint* DynamicsWorld::createJoint(const JointInfo& jointInfo) {
         case SLIDERJOINT:
         {
             void* allocatedMemory = mMemoryAllocator.allocate(sizeof(SliderJoint));
-            const SliderJointInfo& info = dynamic_cast<const SliderJointInfo&>(jointInfo);
+            const SliderJointInfo& info = static_cast<const SliderJointInfo&>(jointInfo);
             newJoint = new (allocatedMemory) SliderJoint(info);
             break;
         }
@@ -548,7 +548,7 @@ Joint* DynamicsWorld::createJoint(const JointInfo& jointInfo) {
         case HINGEJOINT:
         {
             void* allocatedMemory = mMemoryAllocator.allocate(sizeof(HingeJoint));
-            const HingeJointInfo& info = dynamic_cast<const HingeJointInfo&>(jointInfo);
+            const HingeJointInfo& info = static_cast<const HingeJointInfo&>(jointInfo);
             newJoint = new (allocatedMemory) HingeJoint(info);
             break;
         }
@@ -557,7 +557,7 @@ Joint* DynamicsWorld::createJoint(const JointInfo& jointInfo) {
         case FIXEDJOINT:
         {
             void* allocatedMemory = mMemoryAllocator.allocate(sizeof(FixedJoint));
-            const FixedJointInfo& info = dynamic_cast<const FixedJointInfo&>(jointInfo);
+            const FixedJointInfo& info = static_cast<const FixedJointInfo&>(jointInfo);
             newJoint = new (allocatedMemory) FixedJoint(info);
             break;
         }
@@ -746,8 +746,8 @@ void DynamicsWorld::computeIslands() {
                 contactManifold->mIsAlreadyInIsland = true;
 
                 // Get the other body of the contact manifold
-                RigidBody* body1 = dynamic_cast<RigidBody*>(contactManifold->getBody1());
-                RigidBody* body2 = dynamic_cast<RigidBody*>(contactManifold->getBody2());
+                RigidBody* body1 = static_cast<RigidBody*>(contactManifold->getBody1());
+                RigidBody* body2 = static_cast<RigidBody*>(contactManifold->getBody2());
                 RigidBody* otherBody = (body1->getID() == bodyToVisit->getID()) ? body2 : body1;
 
                 // Check if the other body has already been added to the island
@@ -774,8 +774,8 @@ void DynamicsWorld::computeIslands() {
                 joint->mIsAlreadyInIsland = true;
 
                 // Get the other body of the contact manifold
-                RigidBody* body1 = dynamic_cast<RigidBody*>(joint->getBody1());
-                RigidBody* body2 = dynamic_cast<RigidBody*>(joint->getBody2());
+                RigidBody* body1 = static_cast<RigidBody*>(joint->getBody1());
+                RigidBody* body2 = static_cast<RigidBody*>(joint->getBody2());
                 RigidBody* otherBody = (body1->getID() == bodyToVisit->getID()) ? body2 : body1;
 
                 // Check if the other body has already been added to the island


### PR DESCRIPTION
Hi,

I wanted to see if things worked without expensive dynamic_cast (~650 CPU ticks per cast) so I used static_cast instead and everything works just fine! Unit tests and examples run flawlessly. If you want, I can also submit a pull request with the same to the dev branch. (PR also changes .gitignore to ignore vim swapfiles. You can cherry-pick that out if you don't want it, but it would be nice as I intend on contributing again.)


Cheers!
Colin