### PR TITLE
Explicitly use std::sqrt

### DIFF
--- a/src/mathematics/Vector2.h
+++ b/src/mathematics/Vector2.h
@@ -188,7 +188,7 @@ inline void Vector2::setAllValues(decimal newX, decimal newY) {
 
 // Return the length of the vector
 inline decimal Vector2::length() const {
-    return sqrt(x*x + y*y);
+    return std::sqrt(x*x + y*y);
 }
 
 // Return the square of the length of the vector


### PR DESCRIPTION
Explicitly use std::sqrt to avoid triggering ambiguous call errors when sqrt is defined in other namespaces