### PR TITLE
Add accessor methods to ConcaveMeshShape to allow reading back vertic…

### DIFF
--- a/src/collision/shapes/ConcaveMeshShape.cpp
+++ b/src/collision/shapes/ConcaveMeshShape.cpp
@@ -115,6 +115,50 @@ void ConcaveMeshShape::getTriangleVerticesNormals(uint subPart, uint triangleInd
     triangleVertexArray->getTriangleVerticesNormals(triangleIndex, outVerticesNormals);
 }
 
+// Return the indices of the three vertices of a given triangle in the array
+void ConcaveMeshShape::getTriangleVerticesIndices(uint subPart, uint triangleIndex, uint* outVerticesIndices) const {
+
+    // Get the triangle vertex array of the current sub-part
+    TriangleVertexArray* triangleVertexArray = mTriangleMesh->getSubpart(subPart);
+
+    // Get the vertices normals of the triangle
+    triangleVertexArray->getTriangleVerticesIndices(triangleIndex, outVerticesIndices);
+}
+
+// Return the number of sub parts contained in this mesh
+uint ConcaveMeshShape::getNbSubparts() const
+{
+	return mTriangleMesh->getNbSubparts();
+}
+		
+// Return the number of triangles in a sub part
+uint ConcaveMeshShape::getNbTriangles(uint subPart) const
+{
+	assert(mTriangleMesh->getSubpart(subPart));
+	return mTriangleMesh->getSubpart(subPart)->getNbTriangles();
+}
+
+// Return the triangle positions for a specific subpart and triangle index
+void ConcaveMeshShape::getTriangleVertices(uint subPart, uint triangleIndex, Vector3* v1, Vector3* v2, Vector3* v3) const
+{
+	assert(mTriangleMesh->getSubpart(subPart));
+	Vector3 outTriangleVertices[3];
+	getTriangleVertices(subPart, triangleIndex, &outTriangleVertices[0]);
+	*v1 = outTriangleVertices[0];
+	*v2 = outTriangleVertices[1];
+	*v3 = outTriangleVertices[2];
+}
+
+// Return the triangle normals for a specific subpart and triangle index
+void ConcaveMeshShape::getTriangleVerticesNormals(uint subPart, uint triangleIndex, Vector3* n1, Vector3* n2, Vector3* n3) const
+{
+	assert(mTriangleMesh->getSubpart(subPart));
+	Vector3 outTriangleVerticesNormals[3];
+	getTriangleVerticesNormals(subPart, triangleIndex, &outTriangleVerticesNormals[0]);
+	*n1 = outTriangleVerticesNormals[0];
+	*n2 = outTriangleVerticesNormals[1];
+	*n3 = outTriangleVerticesNormals[2];
+}
 
 // Use a callback method on all triangles of the concave shape inside a given AABB
 void ConcaveMeshShape::testAllTriangles(TriangleCallback& callback, const AABB& localAABB) const {

--- a/src/collision/shapes/ConcaveMeshShape.h
+++ b/src/collision/shapes/ConcaveMeshShape.h
@@ -160,6 +160,9 @@ class ConcaveMeshShape : public ConcaveShape {
 
         /// Return the three vertex normals (in the array outVerticesNormals) of a triangle
         void getTriangleVerticesNormals(uint subPart, uint triangleIndex, Vector3* outVerticesNormals) const;
+		
+        /// Return the indices of the three vertices of a given triangle in the array
+        void getTriangleVerticesIndices(uint subPart, uint triangleIndex, uint* outVerticesIndices) const;
 
         /// Compute the shape Id for a given triangle of the mesh
         uint computeTriangleShapeId(uint subPart, uint triangleIndex) const;
@@ -180,6 +183,18 @@ class ConcaveMeshShape : public ConcaveShape {
 
         /// Return the scaling vector
         const Vector3& getScaling() const;
+		
+        /// Return the number of sub parts contained in this mesh
+		uint getNbSubparts() const;
+		
+        /// Return the number of triangles in a sub part
+		uint getNbTriangles(uint subPart) const;
+		
+        /// Return the triangle positions for a specific subpart and triangle index
+		void getTriangleVertices(uint subPart, uint triangleIndex, Vector3* v1, Vector3* v2, Vector3* v3) const;
+
+        /// Return the triangle normals for a specific subpart and triangle index
+		void getTriangleVerticesNormals(uint subPart, uint triangleIndex, Vector3* n1, Vector3* n2, Vector3* n3) const;
 
         /// Return the local bounds of the shape in x, y and z directions.
         virtual void getLocalBounds(Vector3& min, Vector3& max) const override;


### PR DESCRIPTION
Add accessor methods to ConcaveMeshShape to allow reading back vertices and normals for inspection from the user code.