### PR TITLE
Optional triangle vertex array normals generation

### DIFF
--- a/src/collision/TriangleVertexArray.cpp
+++ b/src/collision/TriangleVertexArray.cpp
@@ -50,7 +50,8 @@ using namespace reactphysics3d;
  */
 TriangleVertexArray::TriangleVertexArray(uint nbVertices, const void* verticesStart, uint verticesStride,
                                          uint nbTriangles, const void* indexesStart, uint indexesStride,
-                                         VertexDataType vertexDataType, IndexDataType indexDataType) {
+                                         VertexDataType vertexDataType, IndexDataType indexDataType,
+                                         bool generateNormals) {
     mNbVertices = nbVertices;
     mVerticesStart = static_cast<const uchar*>(verticesStart);
     mVerticesStride = verticesStride;
@@ -65,7 +66,9 @@ TriangleVertexArray::TriangleVertexArray(uint nbVertices, const void* verticesSt
     mAreVerticesNormalsProvidedByUser = false;
 
     // Compute the vertices normals because they are not provided by the user
-    computeVerticesNormals();
+    if (generateNormals) {
+        computeVerticesNormals();
+    }
 }
 
 // Constructor with vertices normals
@@ -264,6 +267,10 @@ void TriangleVertexArray::getTriangleVerticesNormals(uint triangleIndex, Vector3
 
     assert(triangleIndex >= 0 && triangleIndex < mNbTriangles);
 
+    if (!mVerticesNormalsStart) {
+        return;
+    }
+
     // Get the three vertex index of the three vertices of the triangle
     uint verticesIndices[3];
     getTriangleVerticesIndices(triangleIndex, verticesIndices);
@@ -331,6 +338,10 @@ void TriangleVertexArray::getVertex(uint vertexIndex, Vector3* outVertex) {
 void TriangleVertexArray::getNormal(uint vertexIndex, Vector3* outNormal) {
 
     assert(vertexIndex < mNbVertices);
+
+    if (!mVerticesNormalsStart) {
+        return;
+    }
 
     const uchar* vertexNormalPointerChar = mVerticesNormalsStart + vertexIndex * mVerticesNormalsStride;
     const void* vertexNormalPointer = static_cast<const void*>(vertexNormalPointerChar);

--- a/src/collision/TriangleVertexArray.cpp
+++ b/src/collision/TriangleVertexArray.cpp
@@ -60,7 +60,7 @@ TriangleVertexArray::TriangleVertexArray(uint nbVertices, const void* verticesSt
     mIndicesStart = static_cast<const uchar*>(indexesStart);
     mIndicesStride = indexesStride;
     mVertexDataType = vertexDataType;
-    mVertexNormaldDataType = NormalDataType::NORMAL_FLOAT_TYPE;
+    mVertexNormalsDataType = NormalDataType::NORMAL_FLOAT_TYPE;
     mIndexDataType = indexDataType;
     mAreVerticesNormalsProvidedByUser = false;
 
@@ -100,7 +100,7 @@ TriangleVertexArray::TriangleVertexArray(uint nbVertices, const void* verticesSt
     mIndicesStart = static_cast<const uchar*>(indexesStart);
     mIndicesStride = indexesStride;
     mVertexDataType = vertexDataType;
-    mVertexNormaldDataType = normalDataType;
+    mVertexNormalsDataType = normalDataType;
     mIndexDataType = indexDataType;
     mAreVerticesNormalsProvidedByUser = true;
 
@@ -275,13 +275,13 @@ void TriangleVertexArray::getTriangleVerticesNormals(uint triangleIndex, Vector3
         const void* vertexNormalPointer = static_cast<const void*>(vertexNormalPointerChar);
 
         // Get the normals from the array
-        if (mVertexNormaldDataType == TriangleVertexArray::NormalDataType::NORMAL_FLOAT_TYPE) {
+        if (mVertexNormalsDataType == TriangleVertexArray::NormalDataType::NORMAL_FLOAT_TYPE) {
             const float* normal = static_cast<const float*>(vertexNormalPointer);
             outTriangleVerticesNormals[k][0] = decimal(normal[0]);
             outTriangleVerticesNormals[k][1] = decimal(normal[1]);
             outTriangleVerticesNormals[k][2] = decimal(normal[2]);
         }
-        else if (mVertexNormaldDataType == TriangleVertexArray::NormalDataType::NORMAL_DOUBLE_TYPE) {
+        else if (mVertexNormalsDataType == TriangleVertexArray::NormalDataType::NORMAL_DOUBLE_TYPE) {
             const double* normal = static_cast<const double*>(vertexNormalPointer);
             outTriangleVerticesNormals[k][0] = decimal(normal[0]);
             outTriangleVerticesNormals[k][1] = decimal(normal[1]);
@@ -336,13 +336,13 @@ void TriangleVertexArray::getNormal(uint vertexIndex, Vector3* outNormal) {
     const void* vertexNormalPointer = static_cast<const void*>(vertexNormalPointerChar);
 
     // Get the normals from the array
-    if (mVertexNormaldDataType == TriangleVertexArray::NormalDataType::NORMAL_FLOAT_TYPE) {
+    if (mVertexNormalsDataType == TriangleVertexArray::NormalDataType::NORMAL_FLOAT_TYPE) {
         const float* normal = static_cast<const float*>(vertexNormalPointer);
         (*outNormal)[0] = decimal(normal[0]);
         (*outNormal)[1] = decimal(normal[1]);
         (*outNormal)[2] = decimal(normal[2]);
     }
-    else if (mVertexNormaldDataType == TriangleVertexArray::NormalDataType::NORMAL_DOUBLE_TYPE) {
+    else if (mVertexNormalsDataType == TriangleVertexArray::NormalDataType::NORMAL_DOUBLE_TYPE) {
         const double* normal = static_cast<const double*>(vertexNormalPointer);
         (*outNormal)[0] = decimal(normal[0]);
         (*outNormal)[1] = decimal(normal[1]);

--- a/src/collision/TriangleVertexArray.h
+++ b/src/collision/TriangleVertexArray.h
@@ -91,7 +91,7 @@ class TriangleVertexArray {
         VertexDataType mVertexDataType;
 
         /// Data type of the vertex normals in the array
-        NormalDataType mVertexNormaldDataType;
+        NormalDataType mVertexNormalsDataType;
 
         /// Data type of the indices in the array
         IndexDataType mIndexDataType;
@@ -191,7 +191,7 @@ inline TriangleVertexArray::VertexDataType TriangleVertexArray::getVertexDataTyp
  * @return The data type of the normals in the array
  */
 inline TriangleVertexArray::NormalDataType TriangleVertexArray::getVertexNormalDataType() const {
-    return mVertexNormaldDataType;
+    return mVertexNormalsDataType;
 }
 
 // Return the index data type

--- a/src/collision/TriangleVertexArray.h
+++ b/src/collision/TriangleVertexArray.h
@@ -111,7 +111,8 @@ class TriangleVertexArray {
         /// Constructor without vertices normals
         TriangleVertexArray(uint nbVertices, const void* verticesStart, uint verticesStride,
                             uint nbTriangles, const void* indexesStart, uint indexesStride,
-                            VertexDataType vertexDataType, IndexDataType indexDataType);
+                            VertexDataType vertexDataType, IndexDataType indexDataType,
+                            bool generateNormals = true);
 
         /// Constructor with vertices normals
         TriangleVertexArray(uint nbVertices, const void* verticesStart, uint verticesStride,


### PR DESCRIPTION
Hi,

In our project, we don't need normals for raycasting and we don't use rigid body simulations. The computation of normals incur performance and memory usage overhead.

At first, we tried to copy all the stuff related to concave meshes, but we ended up in copying a lot of code for a tiny change.

I'm submitting this pull request to make the computation of normals option. Not sure it's the best way, but at least it raises the idea in the event you come up with something more suitable.

