### PR TITLE
Add rigidBodyUpdated function to EventListener

### DIFF
--- a/src/engine/DynamicsWorld.cpp
+++ b/src/engine/DynamicsWorld.cpp
@@ -229,6 +229,9 @@ void DynamicsWorld::updateBodiesState() {
 
             // Update the broad-phase state of the body
             bodies[b]->updateBroadPhaseState();
+
+            // Notify the event listener that the body has been updated
+            if (mEventListener != nullptr) { mEventListener->rigidBodyUpdated(bodies[b]); }
         }
     }
 }

--- a/src/engine/EventListener.h
+++ b/src/engine/EventListener.h
@@ -66,6 +66,11 @@ class EventListener {
         /// engine will do several internal simulation steps. This method is
         /// called at the end of each internal simulation step.
         virtual void endInternalTick() {}
+
+	/// Called every time a RigidBody is updated as part of the
+	/// DynamicsWorld::update() step. The pointer provided as a parameter
+	/// to this function is the RigidBody that has been updated.
+	virtual void rigidBodyUpdated(const RigidBody* body) {}
 };
 
 }


### PR DESCRIPTION
In my current project, after updating the physics engine, I need to update my own structures with the positions, orientations and velocities of rigid bodies. My initial approach was just to loop through all of my structures after advancing the physics engine and copying out the data that I needed, which was inefficient.

A nicer approach would be to have a callback available that gets called whenever a RigidBody gets updated. I can then implement this function in my EventListener to get out all the information I need. This approach also benefits from sleeping bodies not calling the callback.

I've only quickly thrown this together to get it working for my case, so there may be some work I need to do to improve on this PR.