### PR TITLE
Fixed a bug where changing the transform of a Collider attached to a sleeping RigidBody caused the body to remain asleep

### DIFF
--- a/include/reactphysics3d/body/RigidBody.h
+++ b/include/reactphysics3d/body/RigidBody.h
@@ -222,6 +222,7 @@ class RigidBody : public CollisionBody {
         friend class SolveHingeJointSystem;
         friend class SolveSliderJointSystem;
         friend class Joint;
+        friend class Collider;
 };
 
 /// Compute the inverse of the inertia tensor in world coordinates.

--- a/src/collision/Collider.cpp
+++ b/src/collision/Collider.cpp
@@ -114,7 +114,7 @@ void Collider::setLocalToBodyTransform(const Transform& transform) {
 
     RigidBody* rigidBody = static_cast<RigidBody*>(mBody);
     if (rigidBody != nullptr) {
-        mBody->mWorld.mRigidBodyComponents.setIsSleeping(mBody->getEntity(), false);
+        rigidBody->setIsSleeping(false);
     }
 
     mBody->mWorld.mCollisionDetection.updateCollider(mEntity, 0);


### PR DESCRIPTION
Hello, this bug occurred when I was attempting to change the local to body transform of a Collider while the RigidBody it is attached to is sleeping. It was caused by the Collider::setLocalToBodyTransform() function using the wrong sleep function for a rigid body. Instead, it just updated the sleep status of the body without enabling the body components. I don't think that was the intended behavior, so I tried doing a small fix.