### PR TITLE
Remove involved overlapping pairs when addNoCollisionPair() is called

### DIFF
--- a/include/reactphysics3d/collision/shapes/BoxShape.h
+++ b/include/reactphysics3d/collision/shapes/BoxShape.h
@@ -112,7 +112,7 @@ class BoxShape : public ConvexPolyhedronShape {
         virtual uint32 getNbVertices() const override;
 
         /// Return a given vertex of the polyhedron
-        virtual HalfEdgeStructure::Vertex getVertex(uint32 vertexIndex) const override;
+        virtual const HalfEdgeStructure::Vertex& getVertex(uint32 vertexIndex) const override;
 
         /// Return the number of half-edges of the polyhedron
         virtual uint32 getNbHalfEdges() const override;

--- a/include/reactphysics3d/collision/shapes/ConvexMeshShape.h
+++ b/include/reactphysics3d/collision/shapes/ConvexMeshShape.h
@@ -118,7 +118,7 @@ class ConvexMeshShape : public ConvexPolyhedronShape {
         virtual uint32 getNbVertices() const override;
 
         /// Return a given vertex of the polyhedron
-        virtual HalfEdgeStructure::Vertex getVertex(uint32 vertexIndex) const override;
+        virtual const HalfEdgeStructure::Vertex& getVertex(uint32 vertexIndex) const override;
 
         /// Return the number of half-edges of the polyhedron
         virtual uint32 getNbHalfEdges() const override;
@@ -208,7 +208,7 @@ RP3D_FORCE_INLINE uint32 ConvexMeshShape::getNbVertices() const {
 }
 
 // Return a given vertex of the polyhedron
-RP3D_FORCE_INLINE HalfEdgeStructure::Vertex ConvexMeshShape::getVertex(uint32 vertexIndex) const {
+RP3D_FORCE_INLINE const HalfEdgeStructure::Vertex& ConvexMeshShape::getVertex(uint32 vertexIndex) const {
     assert(vertexIndex < getNbVertices());
     return mPolyhedronMesh->getHalfEdgeStructure().getVertex(vertexIndex);
 }

--- a/include/reactphysics3d/collision/shapes/ConvexPolyhedronShape.h
+++ b/include/reactphysics3d/collision/shapes/ConvexPolyhedronShape.h
@@ -68,7 +68,7 @@ class ConvexPolyhedronShape : public ConvexShape {
         virtual uint32 getNbVertices() const=0;
 
         /// Return a given vertex of the polyhedron
-        virtual HalfEdgeStructure::Vertex getVertex(uint32 vertexIndex) const=0;
+        virtual const HalfEdgeStructure::Vertex& getVertex(uint32 vertexIndex) const=0;
 
         /// Return the position of a given vertex
         virtual Vector3 getVertexPosition(uint32 vertexIndex) const=0;

--- a/include/reactphysics3d/collision/shapes/TriangleShape.h
+++ b/include/reactphysics3d/collision/shapes/TriangleShape.h
@@ -151,7 +151,7 @@ class TriangleShape : public ConvexPolyhedronShape {
         virtual uint32 getNbVertices() const override;
 
         /// Return a given vertex of the polyhedron
-        virtual HalfEdgeStructure::Vertex getVertex(uint32 vertexIndex) const override;
+        virtual const HalfEdgeStructure::Vertex& getVertex(uint32 vertexIndex) const override;
 
         /// Return the position of a given vertex
         virtual Vector3 getVertexPosition(uint32 vertexIndex) const override;
@@ -244,16 +244,9 @@ RP3D_FORCE_INLINE uint32 TriangleShape::getNbVertices() const {
 }
 
 // Return a given vertex of the polyhedron
-RP3D_FORCE_INLINE HalfEdgeStructure::Vertex TriangleShape::getVertex(uint32 vertexIndex) const {
+RP3D_FORCE_INLINE const HalfEdgeStructure::Vertex& TriangleShape::getVertex(uint32 vertexIndex) const {
     assert(vertexIndex < 3);
-
-    HalfEdgeStructure::Vertex vertex(vertexIndex);
-    switch (vertexIndex) {
-        case 0: vertex.edgeIndex = 0; break;
-        case 1: vertex.edgeIndex = 2; break;
-        case 2: vertex.edgeIndex = 4; break;
-    }
-    return vertex;
+    return mTriangleHalfEdgeStructure.getVertex(vertexIndex);
 }
 
 // Return the position of a given vertex

--- a/include/reactphysics3d/systems/CollisionDetectionSystem.h
+++ b/include/reactphysics3d/systems/CollisionDetectionSystem.h
@@ -413,11 +413,6 @@ RP3D_FORCE_INLINE void CollisionDetectionSystem::addCollider(Collider* collider,
     mMapBroadPhaseIdToColliderEntity.add(Pair<int, Entity>(broadPhaseId, collider->getEntity()));
 }
 
-// Add a pair of bodies that cannot collide with each other
-RP3D_FORCE_INLINE void CollisionDetectionSystem::addNoCollisionPair(Entity body1Entity, Entity body2Entity) {
-    mNoCollisionPairs.add(OverlappingPairs::computeBodiesIndexPair(body1Entity, body2Entity));
-}
-
 // Remove a pair of bodies that cannot collide with each other
 RP3D_FORCE_INLINE void CollisionDetectionSystem::removeNoCollisionPair(Entity body1Entity, Entity body2Entity) {
     mNoCollisionPairs.remove(OverlappingPairs::computeBodiesIndexPair(body1Entity, body2Entity));

--- a/src/collision/shapes/BoxShape.cpp
+++ b/src/collision/shapes/BoxShape.cpp
@@ -130,7 +130,7 @@ const HalfEdgeStructure::Face& BoxShape::getFace(uint32 faceIndex) const {
 }
 
 // Return a given vertex of the polyhedron
-HalfEdgeStructure::Vertex BoxShape::getVertex(uint32 vertexIndex) const {
+const HalfEdgeStructure::Vertex& BoxShape::getVertex(uint32 vertexIndex) const {
     assert(vertexIndex < getNbVertices());
     return mPhysicsCommon.mBoxShapeHalfEdgeStructure.getVertex(vertexIndex);
 }

--- a/src/systems/CollisionDetectionSystem.cpp
+++ b/src/systems/CollisionDetectionSystem.cpp
@@ -196,6 +196,34 @@ void CollisionDetectionSystem::addLostContactPair(OverlappingPairs::OverlappingP
     mLostContactPairs.add(lostContactPair);
 }
 
+// Add a pair of bodies that cannot collide with each other
+void CollisionDetectionSystem::addNoCollisionPair(Entity body1Entity, Entity body2Entity) {
+    mNoCollisionPairs.add(OverlappingPairs::computeBodiesIndexPair(body1Entity, body2Entity));
+
+    // If there already are OverlappingPairs involved, they should be removed; Or they will remain in collision state
+    Array<uint64> toBeRemove(mMemoryManager.getPoolAllocator());
+    const Array<Entity>& colliderEntities = mWorld->mCollisionBodyComponents.getColliders(body1Entity);
+    for (uint32 i = 0; i < colliderEntities.size(); ++i) {
+
+        // Get the currently overlapping pairs for colliders of body1
+        const Array<uint64>& overlappingPairs = mCollidersComponents.getOverlappingPairs(colliderEntities[i]);
+
+        for (uint32 j = 0; j < overlappingPairs.size(); ++j) {
+
+            OverlappingPairs::OverlappingPair *pair = mOverlappingPairs.getOverlappingPair(overlappingPairs[j]);
+            assert(pair != nullptr);
+
+            const Entity overlappingBody1 = mOverlappingPairs.mColliderComponents.getBody(pair->collider1);
+            const Entity overlappingBody2 = mOverlappingPairs.mColliderComponents.getBody(pair->collider2);
+            if (overlappingBody1 == body2Entity || overlappingBody2 == body2Entity)
+                toBeRemove.add(overlappingPairs[j]);
+        }
+    }
+
+    for (uint32 i = 0; i < toBeRemove.size(); ++i)
+        mOverlappingPairs.removePair(toBeRemove[i]);
+}
+
 // Take an array of overlapping nodes in the broad-phase and create new overlapping pairs if necessary
 void CollisionDetectionSystem::updateOverlappingPairs(const Array<Pair<int32, int32>>& overlappingNodes) {
 

--- a/src/systems/CollisionDetectionSystem.cpp
+++ b/src/systems/CollisionDetectionSystem.cpp
@@ -770,7 +770,7 @@ void CollisionDetectionSystem::computeOverlapSnapshotContactPairs(NarrowPhaseInf
                 const bool isTrigger = mCollidersComponents.mIsTrigger[collider1Index] || mCollidersComponents.mIsTrigger[collider2Index];
 
                 // Create a new contact pair
-                ContactPair contactPair(narrowPhaseInfoBatch.narrowPhaseInfos[i].overlappingPairId, body1Entity, body2Entity, collider1Entity, collider2Entity, static_cast<uint32>(contactPairs.size()), isTrigger, false);
+                ContactPair contactPair(narrowPhaseInfoBatch.narrowPhaseInfos[i].overlappingPairId, body1Entity, body2Entity, collider1Entity, collider2Entity, static_cast<uint32>(contactPairs.size()), false, isTrigger);
                 contactPairs.add(contactPair);
 
                 setOverlapContactPairId.add(narrowPhaseInfoBatch.narrowPhaseInfos[i].overlappingPairId);


### PR DESCRIPTION
- ConvexPolyhedronShape::getVertex() should return constant references, since we don't have dynamic values to construct now
- If some pairs are already in collision, they should be removed in CollisionDetectionSystem::addNoCollisionPair()