### PR TITLE
feature: Selective debug rendering

### DIFF
--- a/include/reactphysics3d/body/CollisionBody.h
+++ b/include/reactphysics3d/body/CollisionBody.h
@@ -62,6 +62,9 @@ class CollisionBody {
         /// Reference to the world the body belongs to
         PhysicsWorld& mWorld;
 
+        /// Determines if debug information is computed for this body
+        bool mDebugEnabled;
+
 #ifdef IS_RP3D_PROFILING_ENABLED
 
 		/// Pointer to the profiler
@@ -156,6 +159,12 @@ class CollisionBody {
 
         /// Return the body local-space coordinates of a vector given in the world-space coordinates
         Vector3 getLocalVector(const Vector3& worldVector) const;
+
+        /// Set whether or not debug lines are computed for this body
+        void setDebugEnabled(bool enabled);
+
+        /// Return true if debug lines should be computed for this body
+        bool isDebugEnabled() const;
 
 #ifdef IS_RP3D_PROFILING_ENABLED
 

--- a/src/body/CollisionBody.cpp
+++ b/src/body/CollisionBody.cpp
@@ -465,3 +465,19 @@ Vector3 CollisionBody::getLocalPoint(const Vector3& worldPoint) const {
 Vector3 CollisionBody::getLocalVector(const Vector3& worldVector) const {
     return mWorld.mTransformComponents.getTransform(mEntity).getOrientation().getInverse() * worldVector;
 }
+
+// Set whether to compute debug lines on this body
+/**
+ * @param enabled Set to true if this body should have it's debug information computed
+ */
+void CollisionBody::setDebugEnabled(bool enabled) {
+    mDebugEnabled = enabled;
+}
+
+// Returns true if this collision body is computing debug information
+/**
+ * @return Returns true if this body is computing debug information
+ */
+bool CollisionBody::isDebugEnabled() const {
+    return mDebugEnabled;
+}

--- a/src/utils/DebugRenderer.cpp
+++ b/src/utils/DebugRenderer.cpp
@@ -410,7 +410,7 @@ void DebugRenderer::computeDebugRenderingPrimitives(const PhysicsWorld& world) {
 		// Get a body
         const CollisionBody* body = b < nbCollisionBodies ? world.getCollisionBody(b) : world.getRigidBody(b - nbCollisionBodies);
 
-        if (body->isActive()) {
+        if (body->isActive() && body->isDebugEnabled()) {
 
             // For each collider of the body
             for (uint32 c = 0; c < body->getNbColliders(); c++) {


### PR DESCRIPTION
Hi there,

This change adds a boolean state on `CollisionBody` and 2 methods for a setter/getter, which controls whether or not to compute debug lines on a particular collision body. Furthermore, the `DebugRenderer` uses this state to decide whether to enter the body, or to skip it.

The rationale for this change is to allow selectively which bodies to render the debug lines, rather than computing lines for everything. Sometimes you don't care about every physical body when debugging, just a particular body that might be misbehaving.

### Breaking Changes

There is a minor breaking change in that, the default value for this state flag is `false`, so by enabling the debugger, nothing will be computed by default until you set the debug state to true on at least one body. Should this PR be accepted, this should be documented in the user manual, but I'm unsure the proper way of editing `tex` files or the process of generating the PDF.

If you can direct me on the process of updating the documentation, I can build a new PR or add it to this PR.

### Testing

I couldn't find any unit tests regarding the `DebugRenderer`, nor could I figure out how to use the testbed app (CMake kept on complaining that I wasn't in a git repository even though I was) but I have tested these changes in my own project.

I've attempted to follow similar terminology and existing code patterns, but if something is written in a different than preferred way, please do let me know.

I've considered adding this flag onto the `Collider` itself, but I figured that most of the time with debugging, you'd be concerned with the general body as a whole.

Cheers,