### PR TITLE
Fix RaycastInfo contructors

### DIFF
--- a/include/reactphysics3d/collision/RaycastInfo.h
+++ b/include/reactphysics3d/collision/RaycastInfo.h
@@ -61,32 +61,31 @@ struct RaycastInfo {
         decimal hitFraction;
 
         /// Mesh subpart index that has been hit (only used for triangles mesh and -1 otherwise)
-        int meshSubpart;
+        int meshSubpart = -1;
 
         /// Hit triangle index (only used for triangles mesh and -1 otherwise)
-        int triangleIndex;
+        int triangleIndex = -1;
 
         /// Pointer to the hit collision body
-        CollisionBody* body;
+        CollisionBody* body = nullptr;
 
         /// Pointer to the hit collider
-        Collider* collider;
+        Collider* collider = nullptr;
 
         // -------------------- Methods -------------------- //
 
-        /// Constructor
-        RaycastInfo() : meshSubpart(-1), triangleIndex(-1), body(nullptr), collider(nullptr) {
+        RaycastInfo() = default;
 
-        }
+        explicit RaycastInfo(const RaycastInfo& raycastInfo) = default;
 
-        /// Destructor
-        ~RaycastInfo() = default;
-
-        /// Deleted copy constructor
-        RaycastInfo(const RaycastInfo& raycastInfo) = delete;
+        RaycastInfo(RaycastInfo&&) = default;
 
         /// Deleted assignment operator
         RaycastInfo& operator=(const RaycastInfo& raycastInfo) = delete;
+
+        RaycastInfo& operator = (RaycastInfo&&) = default;
+
+        ~RaycastInfo() = default;
 };
 
 // Class RaycastCallback


### PR DESCRIPTION
No reason to have copy constructor or other constructors deleted for this class.

Since these constraints prevent me from passing an instance of this class to other functions, I'd like for them to be removed.

I've made the copy constructor explicit, in case there is a worry of accidentally making an unnecessary copy.