### PR TITLE
Fix bug that breaks transforming a Collider on a CollisionBody

### DIFF
--- a/src/collision/Collider.cpp
+++ b/src/collision/Collider.cpp
@@ -112,7 +112,7 @@ void Collider::setLocalToBodyTransform(const Transform& transform) {
     const Transform& bodyTransform = mBody->mWorld.mTransformComponents.getTransform(mBody->getEntity());
     mBody->mWorld.mCollidersComponents.setLocalToWorldTransform(mEntity, bodyTransform * transform);
 
-    RigidBody* rigidBody = static_cast<RigidBody*>(mBody);
+    RigidBody* rigidBody = dynamic_cast<RigidBody*>(mBody);
     if (rigidBody != nullptr) {
         rigidBody->setIsSleeping(false);
     }


### PR DESCRIPTION
Hi there, I've been implementing `CollisionBody`s and `Colliders` in a game engine, but during testing I struggled to apply transformations to colliders. After calling `setLocalToBodyTransform()`, I would get the following error:
```
Assertion failed: mMapEntityToComponentIndex.containsKey(bodyEntity), file C:\(...)\reactphysics3d\include\reactphysics3d/components/RigidBodyComponents.h, line 418
```
That references this assertion:
```
// Return true if the body is sleeping
RP3D_FORCE_INLINE bool RigidBodyComponents::getIsSleeping(Entity bodyEntity) const {

    assert(mMapEntityToComponentIndex.containsKey(bodyEntity));

    return mIsSleeping[mMapEntityToComponentIndex[bodyEntity]];
}
```
I found it odd that I was hitting an assertion in a `RigidBody` method despite not utilising `RigidBody`s. I believe this is due to some undefined behavior, since `static_cast` isn't guaranteed to return `nullptr` if the body isn't a `RigidBody`, so it then proceeds to try to call some methods it probably shouldn't :D

Switching to `dynamic_cast` has fixed my issue.