### PR TITLE
change GLOBAL_ALIGNMENT to 8 bytes

### DIFF
--- a/include/reactphysics3d/configuration.h
+++ b/include/reactphysics3d/configuration.h
@@ -130,7 +130,7 @@ constexpr uint16 NB_MAX_CONTACT_POINTS_IN_POTENTIAL_MANIFOLD = 256;
 constexpr decimal SAME_CONTACT_POINT_DISTANCE_THRESHOLD = decimal(0.01);
 
 /// Global alignment (in bytes) that all allocators must enforce
-constexpr uint8 GLOBAL_ALIGNMENT = 16;
+constexpr uint8 GLOBAL_ALIGNMENT = 8;
 
 /// Current version of ReactPhysics3D
 const std::string RP3D_VERSION = std::string("0.9.0");

--- a/include/reactphysics3d/memory/DefaultAllocator.h
+++ b/include/reactphysics3d/memory/DefaultAllocator.h
@@ -39,7 +39,7 @@ namespace reactphysics3d {
 // Class DefaultAllocator
 /**
  * This class represents a default memory allocator that uses standard C++ functions
- * to allocated 16-bytes aligned memory.
+ * to allocated 8-bytes aligned memory.
  *
  */
 class DefaultAllocator : public MemoryAllocator {
@@ -53,7 +53,7 @@ class DefaultAllocator : public MemoryAllocator {
         DefaultAllocator& operator=(DefaultAllocator& allocator) = default;
 
         /// Allocate memory of a given size (in bytes) and return a pointer to the
-        /// allocated memory. The returned allocated memory must be 16 bytes aligned.
+        /// allocated memory. The returned allocated memory must be 8 bytes aligned.
         virtual void* allocate(size_t size) override {
 
 // If compiler is Visual Studio
@@ -63,7 +63,7 @@ class DefaultAllocator : public MemoryAllocator {
                 return _aligned_malloc(size, GLOBAL_ALIGNMENT);
 #else
 
-                // Return 16-bytes aligned memory
+                // Return 8-bytes aligned memory
                 return std::aligned_alloc(GLOBAL_ALIGNMENT, size);
 #endif
         }

--- a/include/reactphysics3d/memory/MemoryAllocator.h
+++ b/include/reactphysics3d/memory/MemoryAllocator.h
@@ -51,7 +51,7 @@ class MemoryAllocator {
         MemoryAllocator& operator=(MemoryAllocator& allocator) = default;
 
         /// Allocate memory of a given size (in bytes) and return a pointer to the
-        /// allocated memory. The return allocated memory must be 16 bytes aligned.
+        /// allocated memory. The return allocated memory must be 8 bytes aligned.
         virtual void* allocate(size_t size)=0;
 
         /// Release previously allocated memory.

--- a/include/reactphysics3d/memory/MemoryManager.h
+++ b/include/reactphysics3d/memory/MemoryManager.h
@@ -113,7 +113,7 @@ RP3D_FORCE_INLINE void* MemoryManager::allocate(AllocationType allocationType, s
        case AllocationType::Frame: allocatedMemory =  mSingleFrameAllocator.allocate(size); break;
     }
 
-    assert(allocatedMemory == nullptr || reinterpret_cast<uintptr_t>(allocatedMemory) % 16 == 0);
+    assert(allocatedMemory == nullptr || reinterpret_cast<uintptr_t>(allocatedMemory) % 8 == 0);
 
     return allocatedMemory;
 }

--- a/include/reactphysics3d/memory/PoolAllocator.h
+++ b/include/reactphysics3d/memory/PoolAllocator.h
@@ -82,7 +82,7 @@ class PoolAllocator : public MemoryAllocator {
         static const int NB_HEAPS = 128;
 
         /// Minimum unit size
-        static const size_t MIN_UNIT_SIZE = 16;
+        static const size_t MIN_UNIT_SIZE = 8;
 
         /// Maximum memory unit size. An allocation request of a size smaller or equal to
         /// this size will be handled using the small block allocator. However, for an
@@ -91,7 +91,7 @@ class PoolAllocator : public MemoryAllocator {
         static const size_t MAX_UNIT_SIZE = NB_HEAPS * MIN_UNIT_SIZE;
 
         /// Size of a memory chunk
-        static const size_t BLOCK_SIZE = 16 * MAX_UNIT_SIZE;
+        static const size_t BLOCK_SIZE = 8 * MAX_UNIT_SIZE;
 
         // -------------------- Attributes -------------------- //
 

--- a/src/memory/HeapAllocator.cpp
+++ b/src/memory/HeapAllocator.cpp
@@ -182,7 +182,7 @@ void* HeapAllocator::allocate(size_t size) {
     // Offset the allocated address such that it is properly aligned
     allocatedMemory = computeAlignedAddress(allocatedMemory);
 
-    // Check that allocated memory is 16-bytes aligned
+    // Check that allocated memory is 8-bytes aligned
     assert(reinterpret_cast<uintptr_t>(allocatedMemory) % GLOBAL_ALIGNMENT == 0);
 
     return allocatedMemory;
@@ -324,7 +324,7 @@ void HeapAllocator::reserve(size_t sizeToAllocate) {
     void* memory = mBaseAllocator.allocate(sizeToAllocate + sizeof(MemoryUnitHeader));
     assert(memory != nullptr);
 
-    // Check that allocated memory is 16-bytes aligned
+    // Check that allocated memory is 8-bytes aligned
     assert(reinterpret_cast<uintptr_t>(memory) % GLOBAL_ALIGNMENT == 0);
 
     // Create a new memory unit for the allocated memory

--- a/src/memory/PoolAllocator.cpp
+++ b/src/memory/PoolAllocator.cpp
@@ -118,7 +118,7 @@ void* PoolAllocator::allocate(size_t size) {
         // Allocate memory using default allocation
         void* allocatedMemory = mBaseAllocator.allocate(size);
 
-        // Check that allocated memory is 16-bytes aligned
+        // Check that allocated memory is 8-bytes aligned
         assert(reinterpret_cast<uintptr_t>(allocatedMemory) % GLOBAL_ALIGNMENT == 0);
 
         return allocatedMemory;
@@ -137,7 +137,7 @@ void* PoolAllocator::allocate(size_t size) {
 
         void* allocatedMemory = static_cast<void*>(unit);
 
-        // Check that allocated memory is 16-bytes aligned
+        // Check that allocated memory is 8-bytes aligned
         assert(reinterpret_cast<uintptr_t>(allocatedMemory) % GLOBAL_ALIGNMENT == 0);
 
         return allocatedMemory;
@@ -183,7 +183,7 @@ void* PoolAllocator::allocate(size_t size) {
 
         void* allocatedMemory = newBlock->memoryUnits;
 
-        // Check that allocated memory is 16-bytes aligned
+        // Check that allocated memory is 8-bytes aligned
         assert(reinterpret_cast<uintptr_t>(allocatedMemory) % GLOBAL_ALIGNMENT == 0);
 
         // Return the pointer to the first memory unit of the new allocated block

--- a/src/memory/SingleFrameAllocator.cpp
+++ b/src/memory/SingleFrameAllocator.cpp
@@ -41,7 +41,7 @@ SingleFrameAllocator::SingleFrameAllocator(MemoryAllocator& baseAllocator) : mBa
 
     assert(allocatedMemory != nullptr);
 
-    // Check that allocated memory is 16-bytes aligned
+    // Check that allocated memory is 8-bytes aligned
     assert(reinterpret_cast<uintptr_t>(allocatedMemory) % GLOBAL_ALIGNMENT == 0);
 
     mMemoryBufferStart = static_cast<char*>(allocatedMemory);
@@ -55,7 +55,7 @@ SingleFrameAllocator::~SingleFrameAllocator() {
 }
 
 // Allocate memory of a given size (in bytes) and return a pointer to the
-// allocated memory. Allocated memory must be 16-bytes aligned.
+// allocated memory. Allocated memory must be 8-bytes aligned.
 void* SingleFrameAllocator::allocate(size_t size) {
 
     // Lock the method with a mutex
@@ -83,7 +83,7 @@ void* SingleFrameAllocator::allocate(size_t size) {
     // Increment the offset
     mCurrentOffset += totalSize;
 
-    // Check that allocated memory is 16-bytes aligned
+    // Check that allocated memory is 8-bytes aligned
     assert(reinterpret_cast<uintptr_t>(nextAvailableMemory) % GLOBAL_ALIGNMENT == 0);
 
     // Return the next available memory location


### PR DESCRIPTION
While debugging Android I found that some assertions for byte alignment were failing.

Changing to 8 bytes alignment fixed the issue and I now have my build working on Android