### PR TITLE
fixed GCC 13 incompatibility

### DIFF
--- a/include/reactphysics3d/configuration.h
+++ b/include/reactphysics3d/configuration.h
@@ -29,6 +29,7 @@
 // Libraries
 #include <limits>
 #include <cfloat>
+#include <cstdint>
 #include <utility>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
New GCC release introduced some visible changes, most notably [the removal of cstdint usage inside STL](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes). 

cstdint not being explicitly included in [configuration.h](https://github.com/DanielChappuis/reactphysics3d/blob/master/include/reactphysics3d/configuration.h#L29) totally breaks compilation on GCC 13.
This pull request addresses the issue