### PR TITLE
Fix missing include <cstdint>

### DIFF
--- a/include/reactphysics3d/configuration.h
+++ b/include/reactphysics3d/configuration.h
@@ -27,6 +27,7 @@
 #define	REACTPHYSICS3D_CONFIGURATION_H
 
 // Libraries
+#include <cstdint>
 #include <limits>
 #include <cfloat>
 #include <utility>


### PR DESCRIPTION
`std::int8_t` is used, but not included through `#include <cstdint>`.

This may work in some standard libraries because it is leaked through another header, but not in all. I have seen this cause a problem for a user in our programming community on Discord:
![physics3d](https://github.com/DanielChappuis/reactphysics3d/assets/22040976/bcb2735c-359a-4056-9fe0-76a9bc9524ff)

