### PR TITLE
feat: Don't recursively include files.

### DIFF
--- a/include/reactphysics3d/configuration.h
+++ b/include/reactphysics3d/configuration.h
@@ -76,7 +76,7 @@ using uint64 = std::uint64_t;
 
 struct Entity;
 
-template<typename T1, typename T2> struct Pair;
+template<typename T1, typename T2> class Pair;
 using bodypair = Pair<Entity, Entity>;
 
 // ------------------- Enumerations ------------------- //

--- a/include/reactphysics3d/configuration.h
+++ b/include/reactphysics3d/configuration.h
@@ -30,10 +30,10 @@
 #include <limits>
 #include <cfloat>
 #include <utility>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <reactphysics3d/decimal.h>
-#include <reactphysics3d/containers/Pair.h>
 
 // Compilers
 #if defined(_MSC_VER)
@@ -75,6 +75,8 @@ using int64 = std::int64_t;
 using uint64 = std::uint64_t;
 
 struct Entity;
+
+template<typename T1, typename T2> struct Pair;
 using bodypair = Pair<Entity, Entity>;
 
 // ------------------- Enumerations ------------------- //

--- a/include/reactphysics3d/containers/Map.h
+++ b/include/reactphysics3d/containers/Map.h
@@ -53,7 +53,7 @@ class Map {
         static constexpr float DEFAULT_LOAD_FACTOR = 0.75;
 
         /// Invalid index in the array
-        static constexpr uint64 INVALID_INDEX = -1;
+        static constexpr uint64 INVALID_INDEX = static_cast<uint64_t>(-1);
 
         // -------------------- Attributes -------------------- //
 

--- a/include/reactphysics3d/containers/Set.h
+++ b/include/reactphysics3d/containers/Set.h
@@ -52,7 +52,7 @@ class Set {
         static constexpr float DEFAULT_LOAD_FACTOR = 0.75;
 
         /// Invalid index in the array
-        static constexpr uint64 INVALID_INDEX = -1;
+        static constexpr uint64 INVALID_INDEX = static_cast<uint64_t>(-1);
 
         // -------------------- Attributes -------------------- //
 


### PR DESCRIPTION
I could not get this to compile on clang17 (with pretty permissive compile flags). It worked on MSVC though, quite strange that MSVC allows this behaviour, but I digress.

I forward declare the pair and include <cstdint> for the std::*_t definitions required for the library.

This has not been tested on other compilers or toolchains except for MSVC (cl.exe: Microsoft (R) C/C++ Optimizing Compiler Version 19.37.32824 for x64).

This allows for compilation on clang17.0.3.