### PR TITLE
Don't free Deque on 0 capacity

### DIFF
--- a/include/reactphysics3d/containers/Deque.h
+++ b/include/reactphysics3d/containers/Deque.h
@@ -293,14 +293,16 @@ class Deque {
 
         /// Destructor
         ~Deque() {
+            if (mCapacity > 0) {
 
-            clear();
+                clear();
 
-            // Release the chunks array
-            mAllocator.release(mBuffer, sizeof(T) * mCapacity);
+                // Release the chunks array
+                mAllocator.release(mBuffer, sizeof(T) * mCapacity);
 
-            mCapacity = 0;
-            mBuffer = nullptr;
+                mCapacity = 0;
+                mBuffer = nullptr;
+            }
         }
 
         /// Add an element at the end of the deque


### PR DESCRIPTION
I got a segmentation fault if I didn't add any RigidBodies when PhysicsCommon's destructor ran.
In the allocator release there is an assert for size > 0.