### PR TITLE
OverlapCallback: copy constructor

### DIFF
--- a/include/reactphysics3d/collision/OverlapCallback.h
+++ b/include/reactphysics3d/collision/OverlapCallback.h
@@ -93,7 +93,7 @@ class OverlapCallback {
                 // -------------------- Methods -------------------- //
 
                 /// Copy constructor
-                OverlapPair(const OverlapPair& contactPair) = delete;
+                OverlapPair(const OverlapPair& contactPair) = default;
 
                 /// Assignment operator
                 OverlapPair& operator=(const OverlapPair& contactPair) = delete;


### PR DESCRIPTION
Fix resolves a compilation error on Xcode: copy constructor is needed in line 202, 207.

Return-Value-Optimization is an optimization and doesn't exclude to have a default copy constructor.
