### PR TITLE
Validate Deque mBuffer before releasing the chunks array

### DIFF
--- a/include/reactphysics3d/containers/Deque.h
+++ b/include/reactphysics3d/containers/Deque.h
@@ -296,7 +296,7 @@ class Deque {
 
             clear();
 
-            if (mBuffer != nullptr && mCapacity == 0) {
+            if (mBuffer != nullptr && mCapacity > 0) {
                 // Release the chunks array
                 mAllocator.release(mBuffer, sizeof(T) * mCapacity);
             }

--- a/include/reactphysics3d/containers/Deque.h
+++ b/include/reactphysics3d/containers/Deque.h
@@ -296,8 +296,10 @@ class Deque {
 
             clear();
 
-            // Release the chunks array
-            mAllocator.release(mBuffer, sizeof(T) * mCapacity);
+            if (mBuffer != nullptr && mCapacity == 0) {
+                // Release the chunks array
+                mAllocator.release(mBuffer, sizeof(T) * mCapacity);
+            }
 
             mCapacity = 0;
             mBuffer = nullptr;


### PR DESCRIPTION
added validation to check the mBuffer is not nulltpr and the mCapacity isn't zero before calling mAllocator.release, this prevent crash on calling the destructor on empty buffer