### PR TITLE
fix RigidBody without Collider problem

### DIFF
--- a/src/engine/PhysicsWorld.cpp
+++ b/src/engine/PhysicsWorld.cpp
@@ -728,9 +728,6 @@ void PhysicsWorld::createIslands() {
         // If the body is static, we go to the next body
         if (mRigidBodyComponents.mBodyTypes[b] == BodyType::STATIC) continue;
 
-        // If the body does not have any simulation collider, we skip it
-        if (!mBodyComponents.getHasSimulationCollider(mRigidBodyComponents.mRigidBodies[b]->getEntity())) continue;
-
         // Reset the stack of bodies to visit
         bodyEntitiesToVisit.clear();
 


### PR DESCRIPTION
Applying a force to a RigidBody without colliders the body escapes from Joints.

Resolve this issue:
https://github.com/DanielChappuis/reactphysics3d/issues/388

The functionality was broken by this commit:
https://github.com/DanielChappuis/reactphysics3d/commit/8f46764e4bc5e7a60e028accb4ce2f6d0ab8ec47
