### PR TITLE
Add explicit include of chrono header.

### DIFF
--- a/include/reactphysics3d/utils/DefaultLogger.h
+++ b/include/reactphysics3d/utils/DefaultLogger.h
@@ -37,6 +37,7 @@
 #include <iomanip>
 #include <mutex>
 #include <ctime>
+#include <chrono>
 
 /// ReactPhysics3D namespace
 namespace reactphysics3d {


### PR DESCRIPTION
Visual Studio Code doesn't find chrono namespace: include is needed