### PR TITLE
Fix `TriangleVertexArray.cpp` compilation warning

### DIFF
--- a/src/collision/TriangleVertexArray.cpp
+++ b/src/collision/TriangleVertexArray.cpp
@@ -160,6 +160,8 @@ Vector3 TriangleVertexArray::getVertex(uint32 vertexIndex) const {
     else {
         assert(false);
     }
+
+    return Vector3::zero();
 }
 
 // Return a vertex normal of the array


### PR DESCRIPTION
When attempting to compile with `-Wreturn-type` and `-Werror` flags we get the following error:

```sh
Building CXX object my_repo/reactphysics3d.dir/src/collision/TriangleVertexArray.cpp.o
/Users/my_name/my_repo/reactphysics3d/src/collision/TriangleVertexArray.cpp:163:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
  163 | }
      | ^
```

This is because the end of the `TriangleVertexArray::getVertex` function doesn't have a return statement outside of the else block (which realistically will never get reached, but the compiler still complains). Adding the `return Vector3::zero()` line fixes the issue:
```cpp
Vector3 TriangleVertexArray::getVertex(uint32 vertexIndex) const {
    ...

    if (mVertexDataType == TriangleVertexArray::VertexDataType::VERTEX_FLOAT_TYPE) {
        ...
        return Vector3(decimal(vertices[0]), decimal(vertices[1]), decimal(vertices[2]));
    }
    else if (mVertexDataType == TriangleVertexArray::VertexDataType::VERTEX_DOUBLE_TYPE) {
        ...
        return Vector3(decimal(vertices[0]), decimal(vertices[1]), decimal(vertices[2]));
    }
    else {
        assert(false);
    }

    return Vector3::zero();
}
```

This change makes the `TriangleVertexArray::getVertex` function follow the same return flow as the `TriangleVertexArray::getVertex` function:
```cpp
Vector3 TriangleVertexArray::getVertexNormal(uint32 vertexIndex) const {
    ...

    if (mVertexNormaldDataType == TriangleVertexArray::NormalDataType::NORMAL_FLOAT_TYPE) {
        ...
        return Vector3(decimal(normal[0]), decimal(normal[1]), decimal(normal[2]));
    }
    else if (mVertexNormaldDataType == TriangleVertexArray::NormalDataType::NORMAL_DOUBLE_TYPE) {
        ...
        return Vector3(decimal(normal[0]), decimal(normal[1]), decimal(normal[2]));
    }
    else {
        assert(false);
    }

    return Vector3::zero();
}
```