### PR TITLE
Fix allocator bug for MinGW on Windows

### DIFF
--- a/include/reactphysics3d/memory/DefaultAllocator.h
+++ b/include/reactphysics3d/memory/DefaultAllocator.h
@@ -77,7 +77,7 @@ class DefaultAllocator : public MemoryAllocator {
         virtual void release(void* pointer, size_t /*size*/) override {
 
             // If compiler is Visual Studio
-#ifdef RP3D_COMPILER_VISUAL_STUDIO
+#ifdef RP3D_PLATFORM_WINDOWS
 
                 // Visual Studio doesn't not support standard std:aligned_alloc() method from c++ 17
                 return _aligned_free(pointer);


### PR DESCRIPTION
The original code assumed that MSVC is the only C/C++ compiler for Windows, which caused issues when building the library with MinGW. This is just a simple fix changing the `#ifdef RP3D_COMPILER_VISUAL_STUDIO` preprocessor directive to `#ifdef RP3D_PLATFORM_WINDOWS`