### PR TITLE
Raycast radius

### DIFF
--- a/include/reactphysics3d/collision/shapes/CapsuleShape.h
+++ b/include/reactphysics3d/collision/shapes/CapsuleShape.h
@@ -71,7 +71,7 @@ class CapsuleShape : public ConvexShape {
 
         /// Raycasting method between a ray one of the two spheres end cap of the capsule
         bool raycastWithSphereEndCap(const Vector3& point1, const Vector3& point2,
-                                     const Vector3& sphereCenter, decimal maxFraction,
+                                     const Vector3& sphereCenter, decimal rayRadius, decimal maxFraction,
                                      Vector3& hitLocalPoint, decimal& hitFraction) const;
 
         /// Return the number of bytes used by the collision shape

--- a/include/reactphysics3d/mathematics/Ray.h
+++ b/include/reactphysics3d/mathematics/Ray.h
@@ -50,14 +50,17 @@ struct Ray {
         /// Second point of the ray in world-space
         Vector3 point2;
 
+        /// Radius of the ray in world-space
+        decimal radius;
+
         /// Maximum fraction value
         decimal maxFraction;
 
         // -------------------- Methods -------------------- //
 
         /// Constructor with arguments
-        Ray(const Vector3& p1, const Vector3& p2, decimal maxFrac = decimal(1.0))
-           : point1(p1), point2(p2), maxFraction(maxFrac) {
+        Ray(const Vector3& p1, const Vector3& p2, decimal radius = decimal(0.0), decimal maxFrac = decimal(1.0))
+           : point1(p1), point2(p2), radius(radius), maxFraction(maxFrac) {
 
         }
 };

--- a/include/reactphysics3d/mathematics/Ray.h
+++ b/include/reactphysics3d/mathematics/Ray.h
@@ -34,9 +34,10 @@ namespace reactphysics3d {
 
 // Class Ray
 /**
- * This structure represents a 3D ray represented by two points.
+ * This structure represents a 3D ray represented by two points and a radius.
  * The ray goes from point1 to point1 + maxFraction * (point2 - point1).
- * The points are specified in world-space coordinates.
+ * The points and radius are specified in world-space coordinates.
+ * If the radius is greater than zero, the ray will work as a sphere-sweep. 
  */
 struct Ray {
 

--- a/include/reactphysics3d/utils/DefaultLogger.h
+++ b/include/reactphysics3d/utils/DefaultLogger.h
@@ -37,6 +37,7 @@
 #include <iomanip>
 #include <mutex>
 #include <ctime>
+#include <chrono>
 
 /// ReactPhysics3D namespace
 namespace reactphysics3d {

--- a/src/collision/Collider.cpp
+++ b/src/collision/Collider.cpp
@@ -178,7 +178,7 @@ bool Collider::raycast(const Ray& ray, RaycastInfo& raycastInfo) {
     // Convert the ray into the local-space of the collision shape
     const Transform& localToWorldTransform = mBody->mWorld.mCollidersComponents.getLocalToWorldTransform(mEntity);
     const Transform worldToLocalTransform = localToWorldTransform.getInverse();
-    Ray rayLocal(worldToLocalTransform * ray.point1, worldToLocalTransform * ray.point2, ray.maxFraction);
+    Ray rayLocal(worldToLocalTransform * ray.point1, worldToLocalTransform * ray.point2, ray.radius, ray.maxFraction);
 
     const CollisionShape* collisionShape = mBody->mWorld.mCollidersComponents.getCollisionShape(mEntity);
     bool isHit = collisionShape->raycast(rayLocal, raycastInfo, this, mMemoryManager.getPoolAllocator());

--- a/src/collision/broadphase/DynamicAABBTree.cpp
+++ b/src/collision/broadphase/DynamicAABBTree.cpp
@@ -713,7 +713,7 @@ void DynamicAABBTree::raycast(const Ray& ray, DynamicAABBTreeRaycastCallback& ca
         // If the node is a leaf of the tree
         if (node->isLeaf()) {
 
-            Ray rayTemp(ray.point1, ray.point2, maxFraction);
+            Ray rayTemp(ray.point1, ray.point2, ray.radius, maxFraction);
 
             // Call the callback that will raycast again the broad-phase shape
             decimal hitFraction = callback.raycastBroadPhaseShape(nodeID, rayTemp);

--- a/src/collision/broadphase/DynamicAABBTree.cpp
+++ b/src/collision/broadphase/DynamicAABBTree.cpp
@@ -708,7 +708,7 @@ void DynamicAABBTree::raycast(const Ray& ray, DynamicAABBTreeRaycastCallback& ca
         const TreeNode* node = mNodes + nodeID;
 
         // Test if the ray intersects with the current node AABB
-        if (!node->aabb.testRayIntersect(ray.point1, rayDirectionInverse, maxFraction)) continue;
+        if (!node->aabb.testRayIntersect(ray.point1, rayDirectionInverse, ray.radius, maxFraction)) continue;
 
         // If the node is a leaf of the tree
         if (node->isLeaf()) {

--- a/src/collision/shapes/BoxShape.cpp
+++ b/src/collision/shapes/BoxShape.cpp
@@ -144,8 +144,10 @@ bool BoxShape::raycast(const Ray& ray, RaycastInfo& raycastInfo, Collider* colli
             tMin = t;
         }
         
-        localHitPoint = ray.point1 + tMin * rayDirection;
-        normalDirection = (localHitPoint - contactPointOnBox).getUnit();
+        // From sphere to box
+        Vector3 sphereHitPoint = ray.point1 + tMin * rayDirection;
+        normalDirection = (sphereHitPoint - contactPointOnBox).getUnit();
+        localHitPoint = contactPointOnBox;
     }
     
     raycastInfo.body = collider->getBody();

--- a/src/collision/shapes/HeightFieldShape.cpp
+++ b/src/collision/shapes/HeightFieldShape.cpp
@@ -80,7 +80,7 @@ bool HeightFieldShape::raycast(const Ray& ray, RaycastInfo& raycastInfo, Collide
     // Apply the height-field scale inverse scale factor because the mesh is stored without scaling
     // inside the dynamic AABB tree
     const Vector3 inverseScale(decimal(1.0) / mScale.x, decimal(1.0) / mScale.y, decimal(1.0) / mScale.z);
-    Ray scaledRay(ray.point1 * inverseScale, ray.point2 * inverseScale, ray.maxFraction);
+    Ray scaledRay(ray.point1 * inverseScale, ray.point2 * inverseScale, ray.radius, ray.maxFraction);
 
     if (mHeightField->raycast(scaledRay, raycastInfo, collider, getRaycastTestType(), allocator)) {
 

--- a/src/collision/shapes/SphereShape.cpp
+++ b/src/collision/shapes/SphereShape.cpp
@@ -61,7 +61,10 @@ AABB SphereShape::computeTransformedAABB(const Transform& transform) const {
 bool SphereShape::raycast(const Ray& ray, RaycastInfo& raycastInfo, Collider* collider, MemoryAllocator& /*allocator*/) const {
 
     const Vector3 m = ray.point1;
-    decimal c = m.dot(m) - mMargin * mMargin;
+
+    // "Grow" the sphere with the ray radius
+    decimal extendedMargin = mMargin + ray.radius;
+    decimal c = m.dot(m) - extendedMargin * extendedMargin;
 
     // If the origin of the ray is inside the sphere, we return no intersection
     if (c < decimal(0.0)) return false;
@@ -96,6 +99,11 @@ bool SphereShape::raycast(const Ray& ray, RaycastInfo& raycastInfo, Collider* co
         raycastInfo.hitFraction = t;
         raycastInfo.worldPoint = ray.point1 + t * rayDirection;
         raycastInfo.worldNormal = raycastInfo.worldPoint;
+
+        // Push back the intersection point to account for ray radius
+        if (ray.radius > decimal(0.0)) {
+            raycastInfo.worldPoint -= ray.radius * raycastInfo.worldNormal.getUnit();
+        }
 
         return true;
     }

--- a/src/systems/CollisionDetectionSystem.cpp
+++ b/src/systems/CollisionDetectionSystem.cpp
@@ -1187,6 +1187,8 @@ void CollisionDetectionSystem::raycast(RaycastCallback* raycastCallback, const R
 
     RP3D_PROFILE("CollisionDetectionSystem::raycast()", mProfiler);
 
+    assert(ray.radius >= decimal(0.0));
+
     RaycastTest rayCastTest(raycastCallback);
 
     // Ask the broad-phase algorithm to call the testRaycastAgainstShape()

--- a/test/tests/collision/TestAABB.h
+++ b/test/tests/collision/TestAABB.h
@@ -303,14 +303,14 @@ class TestAABB : public Test {
             const Vector3 ray8Direction = ray8.point2 - ray8.point1;
             const Vector3 ray8DirectionInv(decimal(1.0) / ray8Direction.x, decimal(1.0) / ray8Direction.y, decimal(1.0) / ray8Direction.z);
 
-            rp3d_test(mAABB1.testRayIntersect(ray1.point1, ray1DirectionInv, decimal(1.0)));
-            rp3d_test(!mAABB1.testRayIntersect(ray2.point1, ray2DirectionInv, decimal(1.0)));
-            rp3d_test(mAABB1.testRayIntersect(ray3.point1, ray3DirectionInv, decimal(1.0)));
-            rp3d_test(mAABB1.testRayIntersect(ray4.point1, ray4DirectionInv, decimal(1.0)));
-            rp3d_test(mAABB1.testRayIntersect(ray5.point1, ray5DirectionInv, decimal(1.0)));
-            rp3d_test(mAABB1.testRayIntersect(ray6.point1, ray6DirectionInv, decimal(1.0)));
-            rp3d_test(!mAABB1.testRayIntersect(ray7.point1, ray7DirectionInv, decimal(1.0)));
-            rp3d_test(!mAABB1.testRayIntersect(ray8.point1, ray8DirectionInv, decimal(1.0)));
+            rp3d_test(mAABB1.testRayIntersect(ray1.point1, ray1DirectionInv, decimal(0.0), decimal(1.0)));
+            rp3d_test(!mAABB1.testRayIntersect(ray2.point1, ray2DirectionInv, decimal(0.0), decimal(1.0)));
+            rp3d_test(mAABB1.testRayIntersect(ray3.point1, ray3DirectionInv, decimal(0.0), decimal(1.0)));
+            rp3d_test(mAABB1.testRayIntersect(ray4.point1, ray4DirectionInv, decimal(0.0), decimal(1.0)));
+            rp3d_test(mAABB1.testRayIntersect(ray5.point1, ray5DirectionInv, decimal(0.0), decimal(1.0)));
+            rp3d_test(mAABB1.testRayIntersect(ray6.point1, ray6DirectionInv, decimal(0.0), decimal(1.0)));
+            rp3d_test(!mAABB1.testRayIntersect(ray7.point1, ray7DirectionInv, decimal(0.0), decimal(1.0)));
+            rp3d_test(!mAABB1.testRayIntersect(ray8.point1, ray8DirectionInv, decimal(0.0), decimal(1.0)));
         }
  };
 

--- a/test/tests/collision/TestRaycast.h
+++ b/test/tests/collision/TestRaycast.h
@@ -414,10 +414,10 @@ class TestRaycast : public Test {
             mWorld->raycast(ray1, &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(100.0)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(100.0)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             rp3d_test(!mBoxBody->raycast(ray2, raycastInfo3));
@@ -475,22 +475,22 @@ class TestRaycast : public Test {
             rp3d_test(!mCallback.isHit);
 
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             // ----- Test raycast hits ----- //
@@ -500,7 +500,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray11, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mBoxBody->raycast(ray12, raycastInfo3));
@@ -509,7 +509,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray12, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mBoxBody->raycast(ray13, raycastInfo3));
@@ -518,7 +518,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray13, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mBoxBody->raycast(ray14, raycastInfo3));
@@ -527,7 +527,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray14, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mBoxBody->raycast(ray15, raycastInfo3));
@@ -536,7 +536,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray15, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mBoxBody->raycast(ray16, raycastInfo3));
@@ -545,7 +545,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray16, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
         }
 
@@ -626,10 +626,10 @@ class TestRaycast : public Test {
             mWorld->raycast(ray1, &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(100.0)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(100.0)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             rp3d_test(!mSphereBody->raycast(ray2, raycastInfo3));
@@ -687,22 +687,22 @@ class TestRaycast : public Test {
             rp3d_test(!mCallback.isHit);
 
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             // ----- Test raycast hits ----- //
@@ -712,7 +712,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray11, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mSphereBody->raycast(ray12, raycastInfo3));
@@ -721,7 +721,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray12, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mSphereBody->raycast(ray13, raycastInfo3));
@@ -729,7 +729,7 @@ class TestRaycast : public Test {
             mCallback.reset();
             mWorld->raycast(ray13, &mCallback);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.8)), &mCallback);
 
             rp3d_test(mSphereBody->raycast(ray14, raycastInfo3));
             rp3d_test(mSphereCollider->raycast(ray14, raycastInfo3));
@@ -737,7 +737,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray14, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mSphereBody->raycast(ray15, raycastInfo3));
@@ -746,7 +746,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray15, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mSphereBody->raycast(ray16, raycastInfo3));
@@ -755,7 +755,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray16, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
         }
 
@@ -925,22 +925,22 @@ class TestRaycast : public Test {
             rp3d_test(!mCallback.isHit);
 
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             // ----- Test raycast hits ----- //
@@ -950,7 +950,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray11, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCapsuleBody->raycast(ray12, raycastInfo3));
@@ -959,7 +959,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray12, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCapsuleBody->raycast(ray13, raycastInfo3));
@@ -968,7 +968,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray13, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCapsuleBody->raycast(ray14, raycastInfo3));
@@ -977,7 +977,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray14, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCapsuleBody->raycast(ray15, raycastInfo3));
@@ -986,7 +986,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray15, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCapsuleBody->raycast(ray16, raycastInfo3));
@@ -995,7 +995,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray16, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
         }
 
@@ -1077,10 +1077,10 @@ class TestRaycast : public Test {
             mWorld->raycast(ray1, &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(100.0)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(100.0)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             rp3d_test(!mConvexMeshBody->raycast(ray2, raycastInfo3));
@@ -1138,22 +1138,22 @@ class TestRaycast : public Test {
             rp3d_test(!mCallback.isHit);
 
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             // ----- Test raycast hits ----- //
@@ -1163,7 +1163,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray11, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConvexMeshBody->raycast(ray12, raycastInfo3));
@@ -1172,7 +1172,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray12, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConvexMeshBody->raycast(ray13, raycastInfo3));
@@ -1181,7 +1181,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray13, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConvexMeshBody->raycast(ray14, raycastInfo3));
@@ -1190,7 +1190,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray14, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConvexMeshBody->raycast(ray15, raycastInfo3));
@@ -1199,7 +1199,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray15, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConvexMeshBody->raycast(ray16, raycastInfo3));
@@ -1208,7 +1208,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray16, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
         }
 
@@ -1244,7 +1244,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray1, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray2, raycastInfo));
@@ -1252,7 +1252,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray2, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray2.point1, ray2.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray2.point1, ray2.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray3, raycastInfo));
@@ -1260,7 +1260,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray3, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray3.point1, ray3.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray3.point1, ray3.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray4, raycastInfo));
@@ -1268,7 +1268,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray4, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray4.point1, ray4.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray4.point1, ray4.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray5, raycastInfo));
@@ -1276,7 +1276,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray5, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray5.point1, ray5.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray5.point1, ray5.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray6, raycastInfo));
@@ -1284,7 +1284,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray6, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray6.point1, ray6.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray6.point1, ray6.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             // Raycast hit agains the capsule shape
@@ -1302,7 +1302,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray11, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray12, raycastInfo));
@@ -1310,7 +1310,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray12, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray13, raycastInfo));
@@ -1318,7 +1318,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray13, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray14, raycastInfo));
@@ -1326,7 +1326,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray14, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray15, raycastInfo));
@@ -1334,7 +1334,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray15, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mCompoundBody->raycast(ray16, raycastInfo));
@@ -1342,7 +1342,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray16, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
         }
 
@@ -1442,10 +1442,10 @@ class TestRaycast : public Test {
             mWorld->raycast(ray1, &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(100.0)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(100.0)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             rp3d_test(!mConcaveMeshBody->raycast(ray2, raycastInfo3));
@@ -1503,22 +1503,22 @@ class TestRaycast : public Test {
             rp3d_test(!mCallback.isHit);
 
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             // ----- Test raycast hits ----- //
@@ -1528,7 +1528,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray11, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConcaveMeshBody->raycast(ray12, raycastInfo3));
@@ -1537,7 +1537,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray12, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConcaveMeshBody->raycast(ray13, raycastInfo3));
@@ -1546,7 +1546,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray13, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConcaveMeshBody->raycast(ray14, raycastInfo3));
@@ -1555,7 +1555,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray14, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConcaveMeshBody->raycast(ray15, raycastInfo3));
@@ -1564,7 +1564,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray15, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray15.point1, ray15.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mConcaveMeshBody->raycast(ray16, raycastInfo3));
@@ -1573,7 +1573,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray16, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray16.point1, ray16.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
         }
 
@@ -1681,10 +1681,10 @@ class TestRaycast : public Test {
             mWorld->raycast(ray1, &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(100.0)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0), decimal(100.0)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             rp3d_test(!mHeightFieldBody->raycast(ray2, raycastInfo3));
@@ -1720,7 +1720,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray11, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0.95)), &mCallback);
+            mWorld->raycast(Ray(ray11.point1, ray11.point2, decimal(0), decimal(0.95)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mHeightFieldBody->raycast(ray12, raycastInfo3));
@@ -1729,7 +1729,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray12, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0.92)), &mCallback);
+            mWorld->raycast(Ray(ray12.point1, ray12.point2, decimal(0), decimal(0.92)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mHeightFieldBody->raycast(ray13, raycastInfo3));
@@ -1738,7 +1738,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray13, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0.8)), &mCallback);
+            mWorld->raycast(Ray(ray13.point1, ray13.point2, decimal(0), decimal(0.8)), &mCallback);
             rp3d_test(mCallback.isHit);
 
             rp3d_test(mHeightFieldBody->raycast(ray14, raycastInfo3));
@@ -1747,7 +1747,7 @@ class TestRaycast : public Test {
             mWorld->raycast(ray14, &mCallback);
             rp3d_test(mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0.82)), &mCallback);
+            mWorld->raycast(Ray(ray14.point1, ray14.point2, decimal(0), decimal(0.82)), &mCallback);
             rp3d_test(mCallback.isHit);
         }
 };

--- a/test/tests/collision/TestRaycast.h
+++ b/test/tests/collision/TestRaycast.h
@@ -865,10 +865,10 @@ class TestRaycast : public Test {
             mWorld->raycast(ray1, &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.01)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.0), decimal(0.01)), &mCallback);
             rp3d_test(!mCallback.isHit);
             mCallback.reset();
-            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(100.0)), &mCallback);
+            mWorld->raycast(Ray(ray1.point1, ray1.point2, decimal(0.0), decimal(100.0)), &mCallback);
             rp3d_test(!mCallback.isHit);
 
             rp3d_test(!mCapsuleBody->raycast(ray2, raycastInfo3));


### PR DESCRIPTION
It is now possible to specify a radius in the Ray struct. This allows the user to perform sweeps against the world. By default, radius is zero and the raycast functionality works as per usual. 

Sweeps have been implemented for the following shapes:
- AABB
- Box
- Capsule
- Sphere
- Triangle

The remaining shapes are:
- ConcaveMesh
- ConvexMesh
- HeightField

I could implement it for those shapes as well if you think it would be useful.

One thing that needs to be discussed is which raycast-position and normal should be returned:
For the position you can either return the hit-position where the ray and shape intersect, or the position along the ray where the intersection happened. I'm currently returning the first of these. 
For the normal you can either return the surface-normal of the shape that was intersected, or the direction from the hit-position to the position along the ray. I'm currently returning the second of these. 
In both case, both of the values are interesting, depending on the situation. Do you think we should extend RaycastInfo with these variables?

This was requested in #243 and #433.