### PR TITLE
[Logging] Fixed Segmentation Fault in PhysicsWorld destructor after d…

### DIFF
--- a/src/engine/PhysicsCommon.cpp
+++ b/src/engine/PhysicsCommon.cpp
@@ -798,6 +798,9 @@ void PhysicsCommon::destroyDefaultLogger(DefaultLogger* logger) {
  * @param logger A pointer to the default logger to destroy
  */
 void PhysicsCommon::deleteDefaultLogger(DefaultLogger* logger) {
+    if (logger == mLogger) {
+        setLogger(nullptr);
+    }
 
    // Call the destructor of the logger
    logger->~DefaultLogger();


### PR DESCRIPTION
Fixed segmentation fault when destroying default Logger. 

destroyDefaulLogger(DefaultLogger*) now checks if the logger is the static mLogger and if so then sets it to nullptr.

Fixed Issue #443.