### PR TITLE
fix : issue #435 : documentation contains wrong method name.

### DIFF
--- a/documentation/UserDocumentation.md
+++ b/documentation/UserDocumentation.md
@@ -808,7 +808,7 @@ by setting the lock factor to zero for this axis.
 
 ~~~.cpp
 // Disable rotation around the Y axis
-rigidBody->setAngularAxisFactor(Vector3(1, 0, 1));
+rigidBody->setAngularLockAxisFactor(Vector3(1, 0, 1));
 ~~~
 
 ### Destroying a Rigid Body {#destroyingbody}


### PR DESCRIPTION
the documentation wrongfully contains `rigidBody->setAngularAxisFactor();`  
instead of `rigidBody->setAngularLockAxisFactor();`.  (line 811)
The former is not a method, the latter is the correct method for that example. 
(line 805 also proves that the funtion was meant to be  `rigidBody->setAngularLockAxisFactor();`.)